### PR TITLE
feat: add Featured Projects section with The Other Side of Kyoto

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,8 @@ factory, github
 - [github](https://github.com/marclanson)
 - [linkedin](https://linkedin.com/marclanson)
 
+## featured projects
+- [The Other Side of Kyoto](https://theothersideofkyoto.com) — An information portal for Northern Kyoto.
+
 ## credits
 This site is inspired by [Ben Tossell's](https://x.com/bentossell) work.


### PR DESCRIPTION
Added a new Featured Projects section to README.md listing The Other Side of Kyoto as an information portal for Northern Kyoto.

Closes #3